### PR TITLE
Update to Feliz 3.0 compatibility

### DIFF
--- a/src/Feliz.Reactour/Interop.fs
+++ b/src/Feliz.Reactour/Interop.fs
@@ -13,5 +13,5 @@ module Interop =
     let inline mkStyleProp (key: string) (value: obj) : IStyleProp = unbox (key, value)
     let inline mkStepsProp (key: string) (value: obj) : IStepsProp = unbox (key, value)
     let inline mkStepProp (key: string) (value: obj) : IStepProp = unbox (key, value)
-    let TourProvider: obj = import "TourProvider" "@reactour/tour"
+    let TourProvider: Feliz.ReactElement = import "TourProvider" "@reactour/tour"
     let useTour: unit -> obj = import "useTour" "@reactour/tour"

--- a/src/Feliz.Reactour/TourProvider.fs
+++ b/src/Feliz.Reactour/TourProvider.fs
@@ -12,7 +12,7 @@ type TourProvider =
     /// Creates a new TourProvider component.
 
     static member inline tourProvider(props: IReactourProp seq) =
-        Interop.reactApi.createElement (Interop.TourProvider, createObj !!props)
+        ReactLegacy.createElement (Interop.TourProvider, createObj !!props)
 
     static member inline useTour() = Interop.TourProvider
 


### PR DESCRIPTION
## Summary
- Replace `Interop.reactApi.createElement` with `ReactLegacy.createElement`
- Change component imports from `obj` to `ReactElement` type

This fixes compatibility with Feliz 3.0 which removed the `ReactApi` module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)